### PR TITLE
Enable building of Windows assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -759,7 +759,7 @@ dev-build: clean linux-x64-dev-build packages-dev package-links linux-x64-dev-co
 
 .PHONY: release-build
 ## release-build: generates stable build assets for public release
-release-build: clean linux-x86 packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums linux-x64-links package-links
+release-build: clean windows linux-x86 packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums links
 	@echo "Completed all tasks for stable release build"
 
 .PHONY: helper-builder-setup


### PR DESCRIPTION
This was intended to be included in the initial release, but the project I used as a template when bootstraping this one did not include those.