### PR TITLE
Remove unused config constant

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -72,7 +72,6 @@ const (
 	defaultEmitBranding          bool   = false
 	defaultEmitSSHCommandOutput  bool   = false
 	defaultDisplayVersionAndExit bool   = false
-	defaultShowAllProcesses      bool   = false
 	defaultServer                string = ""
 	defaultUsername              string = ""
 	defaultPassword              string = ""


### PR DESCRIPTION
Remove config constant that was inadvertently left behind after bootstrapping this project using the atc0005/check-process project as a starting point.