### PR TITLE
List supported network types in flag help text

### DIFF
--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -58,7 +58,13 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 	c.flagSet.StringVar(&c.Username, UsernameFlagLong, defaultUsername, usernameFlagHelp)
 	c.flagSet.StringVar(&c.Password, PasswordFlagLong, defaultPassword, passwordFlagHelp)
 	c.flagSet.IntVar(&c.TCPPort, PortFlagLong, defaultTCPPort, tcpPortFlagHelp)
-	c.flagSet.StringVar(&c.NetworkType, NetTypeFlagLong, defaultNetworkType, networkTypeFlagHelp)
+
+	c.flagSet.StringVar(
+		&c.NetworkType,
+		NetTypeFlagLong,
+		defaultNetworkType,
+		supportedValuesFlagHelpText(networkTypeFlagHelp, supportedNetworkTypes()),
+	)
 
 	switch {
 	case appType.Inspector:


### PR DESCRIPTION
List these network types in flag help text:

- auto
- tcp4
- tcp6

This is already spelled out explicitly in the text but these changes adds a concise list at the end of the flag help text.