### PR TITLE
Correct logging format listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ results.
   - default behavior is `auto`
 
 - Optional, leveled logging using `rs/zerolog` package
-  - JSON-format output (to `stderr`)
+  - [`logfmt`][logfmt] format output (to `stderr`)
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
     default), `debug` or `trace`
 
@@ -613,3 +613,5 @@ See the [LICENSE](LICENSE) file for details.
 [go-supported-releases]: <https://go.dev/doc/devel/release#policy> "Go Release Policy"
 
 [nagios-illegal-macro-chars]: <https://serverfault.com/questions/242357/need-to-have-illegal-characters-in-nagios-serviceoutput-and-longserviceoutput> "Nagios Illegal Macro Output Characters"
+
+[logfmt]: <https://brandur.org/logfmt>


### PR DESCRIPTION
The logging output format was previously listed as `JSON`. Update this to correctly indicate that this project currently uses the `logfmt` format instead.

refs atc0005/todo#64
refs https://brandur.org/logfmt