### PR TITLE
Update RPM postinstall scripts to use restorecon

### DIFF
--- a/packages/dev/scripts/rpm/postinstall.sh
+++ b/packages/dev/scripts/rpm/postinstall.sh
@@ -40,13 +40,7 @@ if [ -x "$(command -v selinuxenabled)" ]; then
         do
 
             echo -e "\nApplying SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
-
-            chcon \
-                --verbose \
-                -t nagios_unconfined_plugin_exec_t \
-                -u system_u \
-                -r object_r \
-                "${plugin_path}/${plugin_name}${plugin_name_suffix}"
+            restorecon -v ${plugin_path}/${plugin_name}
 
             if [ $? -eq 0 ]; then
                 echo -e "[OK] Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"

--- a/packages/stable/scripts/rpm/postinstall.sh
+++ b/packages/stable/scripts/rpm/postinstall.sh
@@ -40,13 +40,7 @@ if [ -x "$(command -v selinuxenabled)" ]; then
         do
 
             echo -e "\nApplying SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
-
-            chcon \
-                --verbose \
-                -t nagios_unconfined_plugin_exec_t \
-                -u system_u \
-                -r object_r \
-                "${plugin_path}/${plugin_name}${plugin_name_suffix}"
+            restorecon -v ${plugin_path}/${plugin_name}
 
             if [ $? -eq 0 ]; then
                 echo -e "[OK] Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"


### PR DESCRIPTION
Replace calls to chcon and explicit context details with restorecon to allow inheriting previously configured SELinux settings.

refs atc0005/todo#63