### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -15,6 +15,10 @@ const myAppURL string = "https://github.com/atc0005/check-ssh"
 // See https://tldp.org/LDP/abs/html/exitcodes.html for additional details.
 const ExitCodeCatchall int = 1
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Shared flags help text.
 const (
 	versionFlagHelp          string = "Whether to display application version and then immediately exit application."

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -36,7 +36,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 	}
 
 	// shared flags
-	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+shorthandFlagSuffix)
 	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagLong, defaultHelp, helpFlagHelp)
 
 	c.flagSet.BoolVar(&c.ShowVersion, VersionFlagLong, defaultDisplayVersionAndExit, versionFlagHelp)
@@ -45,7 +45,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 		&c.LoggingLevel,
 		LogLevelFlagShort,
 		defaultLogLevel,
-		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels())+" (shorthand)",
+		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels())+shorthandFlagSuffix,
 	)
 	c.flagSet.StringVar(
 		&c.LoggingLevel,
@@ -72,7 +72,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 		c.flagSet.BoolVar(&c.ShowVerbose, VerboseFlagLong, defaultVerbose, verboseFlagHelp)
 		c.flagSet.BoolVar(&c.EmitSSHCommandOutput, SSHCommandOutputFlagLong, defaultEmitSSHCommandOutput, sshCommandOutputFlagHelp)
 
-		c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultTimeout, timeoutFlagHelp+" (shorthand)")
+		c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultTimeout, timeoutFlagHelp+shorthandFlagSuffix)
 		c.flagSet.IntVar(&c.timeout, TimeoutFlagLong, defaultTimeout, timeoutFlagHelp)
 
 		c.flagSet.StringVar(&c.SSHCommand, SSHCommandFlagLong, defaultSSHCommand, sshCommandFlagHelp)


### PR DESCRIPTION
Replace literal text with new `shorthandFlagSuffix` config constant.