### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/check_ssh_login/summary.go
+++ b/cmd/check_ssh_login/summary.go
@@ -55,7 +55,7 @@ func setLongServiceOutput(extendedMessage string, client *ssh.Client, cfg *confi
 	// 	nagios.CheckOutputEOL,
 	// )
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sConfiguration settings: %s%s",
 		nagios.CheckOutputEOL,
@@ -63,49 +63,49 @@ func setLongServiceOutput(extendedMessage string, client *ssh.Client, cfg *confi
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Server: %v%s",
 		cfg.Server,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Port: %v%s",
 		cfg.TCPPort,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Username: %v%s",
 		cfg.Username,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* NetworkType: %v%s",
 		cfg.NetworkType,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Timeout: %v%s",
 		cfg.Timeout(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* LoginFailureState: %v%s",
 		strings.ToUpper(cfg.LoginFailureState),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* LoginSuccessState: %v%s",
 		strings.ToUpper(cfg.LoginSuccessState),
@@ -113,7 +113,7 @@ func setLongServiceOutput(extendedMessage string, client *ssh.Client, cfg *confi
 	)
 
 	if extendedMessage != "" {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"%s------%s%s",
 			nagios.CheckOutputEOL,
@@ -121,7 +121,7 @@ func setLongServiceOutput(extendedMessage string, client *ssh.Client, cfg *confi
 			nagios.CheckOutputEOL,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"%s%s",
 			nagios.CheckOutputEOL,
@@ -129,7 +129,7 @@ func setLongServiceOutput(extendedMessage string, client *ssh.Client, cfg *confi
 		)
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s",
 		nagios.CheckOutputEOL,
@@ -137,13 +137,13 @@ func setLongServiceOutput(extendedMessage string, client *ssh.Client, cfg *confi
 
 	if cfg.ShowVerbose {
 		if client != nil {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"SSH Client version: %s%s",
 				client.ClientVersion(),
 				nagios.CheckOutputEOL,
 			)
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"SSH Server version: %s%s",
 				client.ServerVersion(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,7 +216,7 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 	// Uninitialized flagset, provide stub usage information.
 	case flagSet == nil:
 		return func() {
-			fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
+			_, _ = fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
 		}
 
 	// Non-nil flagSet, proceed
@@ -226,8 +226,8 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 		flagSet.SetOutput(w)
 
 		return func() {
-			fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+			_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 			flagSet.PrintDefaults()
 		}
 	}
@@ -245,7 +245,7 @@ func (c *Config) Help() string {
 	// Handle nil configuration initialization.
 	case c == nil || c.flagSet == nil:
 		// Fallback message noting the issue.
-		fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
+		_, _ = fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
 
 	default:
 		// Emit expected help output to builder.


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
