### PR TITLE
Update dev branch to Go 1.23 series point release

### DIFF
--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.23
+FROM golang:1.23.2


### PR DESCRIPTION
Update "canary" Dockerfile from the 1.23 series to reflect previous Go
1.23 point release. This should trigger a Dependabot update for this
file to the next available point release.
